### PR TITLE
Fix --model option in simscore command

### DIFF
--- a/packages/embcli-core/src/embcli_core/cli.py
+++ b/packages/embcli-core/src/embcli_core/cli.py
@@ -95,7 +95,7 @@ def embed(env_file, model_id, file, options, text):
 
 @cli.command()
 @click.option("--env-file", "-e", default=".env", help="Path to the .env file")
-@click.option("model_id", "--model", "-m", default="text-embedding-3-small", help="Model alias to use for embedding")
+@click.option("model_id", "--model", "-m", help="Model id or alias to use for embedding")
 @click.option(
     "--similarity",
     "-s",


### PR DESCRIPTION
follow-up of #4

Apply minor fixes in `--model` option for  `simscore` command.
- Remove default value
- Fix help message