### PR TITLE
Add command to ingest sample data

### DIFF
--- a/packages/embcli-core/tests/embcli_core/test_cli_ingest_sample.py
+++ b/packages/embcli-core/tests/embcli_core/test_cli_ingest_sample.py
@@ -1,0 +1,37 @@
+from click.testing import CliRunner
+from embcli_core.cli import ingest_sample
+from embcli_core.vector_store import chroma
+
+
+def test_ingest_command(plugin_manager, mocker, tmp_path):
+    """Test the ingest command."""
+    plugin_manager.register(chroma)
+    mocker.patch("embcli_core.cli._pm", plugin_manager)
+
+    test_persist_path = tmp_path / "test_db"
+    test_persist_path.mkdir(parents=True, exist_ok=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        ingest_sample,
+        [
+            "--model",
+            "embedding-mock-1",
+            "--vector-store",
+            "chroma",
+            "--persist-path",
+            str(test_persist_path),
+            "--collection",
+            "test_collection",
+            "--corpus",
+            "cat-names",
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Check if the output contains the expected success message
+    assert "chroma" in result.output
+    assert str(test_persist_path) in result.output
+
+    # Check if the database was created
+    assert test_persist_path.exists()


### PR DESCRIPTION
**Usage**

```
$ emb ingest-sample --help
Usage: emb ingest-sample [OPTIONS]

  Ingest documents into the vector store.

Options:
  -e, --env-file TEXT          Path to the .env file
  -m, --model TEXT             Model id or alias to use for embedding
                               [required]
  --vector-store TEXT          Vector store to use for storing embeddings
                               [default: chroma]
  --persist-path TEXT          Path to persist the vector store
  -c, --collection TEXT        Collection name where to store the embeddings
                               [required]
  --corpus [cat-names]         Smaple corpus name to use  [default: cat-names]
  -o, --option <TEXT TEXT>...  key/value options for the model
  --help                       Show this message and exit.
```

```
$ emb ingest-sample -m 3-small -c catshop --persist-path testdb
Documents ingested successfully.
Vector store: chroma (collection: catshop)
Persist path: testdb
```