### PR TITLE
Use proper model options when generating embeddings for ingestion/search

### DIFF
--- a/packages/embcli-cohere/src/embcli_cohere/cohere_model.py
+++ b/packages/embcli-cohere/src/embcli_cohere/cohere_model.py
@@ -51,6 +51,14 @@ class CohereEmbeddingModel(EmbeddingModel):
         for embedding in response.embeddings.float_:
             yield embedding
 
+    def embed_batch_for_ingest(self, input, batch_size, **kwargs):
+        kwargs["input_type"] = "search_document"
+        return self.embed_batch(input, batch_size, **kwargs)
+
+    def embed_for_search(self, input, **kwargs):
+        kwargs["input_type"] = "search_query"
+        return self.embed(input, **kwargs)
+
 
 @embcli_core.hookimpl
 def embedding_model():

--- a/packages/embcli-cohere/tests/embcli_cohere/test_cohere_model.py
+++ b/packages/embcli-cohere/tests/embcli_cohere/test_cohere_model.py
@@ -49,3 +49,27 @@ def test_embed_batch_with_options(cohere_models):
     for emb in embeddings:
         assert isinstance(emb, list)
         assert all(isinstance(x, float) for x in emb)
+
+
+@skip_if_no_api_key
+def test_embed_batch_for_ingest(cohere_models, mocker):
+    for model in cohere_models:
+        input_data = ["hello", "world"]
+        spy = mocker.spy(model, "embed_batch")
+        embeddings = list(model.embed_batch_for_ingest(input_data, None))
+        assert len(embeddings) > 0
+
+        # Check that the spy was called with the correct model options
+        spy.assert_called_once_with(input_data, None, input_type="search_document")
+
+
+@skip_if_no_api_key
+def test_embed_for_search(cohere_models, mocker):
+    for model in cohere_models:
+        input = "hello world"
+        spy = mocker.spy(model, "embed")
+        embedding = list(model.embed_for_search(input))
+        assert len(embedding) > 0
+
+        # Check that the spy was called with the correct model options
+        spy.assert_called_once_with(input, input_type="search_query")

--- a/packages/embcli-core/src/embcli_core/cli.py
+++ b/packages/embcli-core/src/embcli_core/cli.py
@@ -188,7 +188,8 @@ def simscore(env_file, model_id, similarity, file1, file2, options, text1, text2
 @click.option("--batch-size", default=100, type=int, help="Batch size for embedding", show_default=True)
 @click.option("options", "--option", "-o", type=(str, str), multiple=True, help="key/value options for the model")
 def ingest(env_file, model_id, vector_store_vendor, persist_path, collection, file, input_format, batch_size, options):
-    """Ingest documents into the vector store."""
+    """Ingest documents into the vector store.
+    Ingestion-specific embeddings are used if the model provides options for generating search documents-optimized embeddings."""  # noqa: E501
     register_models(pm())
     register_vector_stores(pm())
     load_env(env_file)
@@ -249,7 +250,7 @@ def ingest(env_file, model_id, vector_store_vendor, persist_path, collection, fi
 )
 @click.option("options", "--option", "-o", type=(str, str), multiple=True, help="key/value options for the model")
 def ingest_sample(env_file, model_id, vector_store_vendor, persist_path, collection, corpus, options):
-    """Ingest documents into the vector store."""
+    """Ingest example documents into the vector store."""
     register_models(pm())
     register_vector_stores(pm())
     load_env(env_file)
@@ -305,7 +306,8 @@ def ingest_sample(env_file, model_id, vector_store_vendor, persist_path, collect
 @click.option("--top-k", "-k", default=5, type=int, help="Number of top results to return", show_default=True)
 @click.option("options", "--option", "-o", type=(str, str), multiple=True, help="key/value options for the model")
 def search(env_file, model_id, vector_store_vendor, persist_path, collection, query, top_k, options):
-    """Search for documents in the vector store."""
+    """Search for documents in the vector store for the query.
+    Query-specific embedding is used if the model provides options for generating search query-optimized embeddings."""  # noqa: E501
     register_models(pm())
     register_vector_stores(pm())
     load_env(env_file)

--- a/packages/embcli-core/src/embcli_core/models.py
+++ b/packages/embcli-core/src/embcli_core/models.py
@@ -43,6 +43,11 @@ class EmbeddingModel(ABC):
         model_options = self._check_and_convert_options(**kwargs)
         return next(self._embed_one_batch([input], **model_options))
 
+    def embed_for_search(self, input: str, **kwargs) -> list[float]:
+        """Generate an embedding for a single input. Output is supposed to be used for search query."""
+        # This method is a placeholder and can be overridden by subclasses if needed.
+        return self.embed(input, **kwargs)
+
     def embed_batch(self, input: list[str], batch_size: Optional[int], **kwargs) -> Iterator[list[float]]:
         """Generate embeddings for a list of inputs. Inputs are split into batches of size `batch_size`.
         Args:
@@ -59,6 +64,11 @@ class EmbeddingModel(ABC):
             batch_size = self.default_batch_size
         for i in range(0, len(input), batch_size):
             yield from self._embed_one_batch(input[i : i + batch_size], **model_options)
+
+    def embed_batch_for_ingest(self, input: list[str], batch_size: Optional[int], **kwargs) -> Iterator[list[float]]:
+        """Generate embeddings for a list of inputs. Outputs are supposed to be used for ingestion."""
+        # This method is a placeholder and can be overridden by subclasses if needed.
+        return self.embed_batch(input, batch_size, **kwargs)
 
     @abstractmethod
     def _embed_one_batch(self, input: list[str], **kwargs) -> Iterator[list[float]]:

--- a/packages/embcli-core/tests/embcli_core/test_vector_stores.py
+++ b/packages/embcli-core/tests/embcli_core/test_vector_stores.py
@@ -4,7 +4,7 @@ from embcli_core.vector_stores import available_vector_stores, get_vector_store,
 
 def test_ingest(mock_model, mock_store, mocker):
     spy1 = mocker.spy(mock_store, "_index")
-    spy2 = mocker.spy(mock_model, "embed_batch")
+    spy2 = mocker.spy(mock_model, "embed_batch_for_ingest")
     collection = "test_collection"
     documents = [Document("doc1", "This is a test document."), Document("doc2", "Another test document.")]
     mock_store.ingest(mock_model, collection, documents)
@@ -14,7 +14,7 @@ def test_ingest(mock_model, mock_store, mocker):
 
 def test_ingest_with_batch_size(mock_model, mock_store, mocker):
     spy1 = mocker.spy(mock_store, "_index")
-    spy2 = mocker.spy(mock_model, "embed_batch")
+    spy2 = mocker.spy(mock_model, "embed_batch_for_ingest")
     collection = "test_collection"
     documents = [Document(f"doc{i}", "This is a test document.") for i in range(10)]
     batch_size = 3
@@ -25,7 +25,7 @@ def test_ingest_with_batch_size(mock_model, mock_store, mocker):
 
 def test_search(mock_model, mock_store, mocker):
     spy1 = mocker.spy(mock_store, "_search")
-    spy2 = mocker.spy(mock_model, "embed")
+    spy2 = mocker.spy(mock_model, "embed_for_search")
     collection = "test_collection"
     query = "test query"
     top_k = 3

--- a/packages/embcli-gemini/src/embcli_gemini/gemini.py
+++ b/packages/embcli-gemini/src/embcli_gemini/gemini.py
@@ -19,7 +19,7 @@ class GeminiEmbeddingModel(EmbeddingModel):
         ModelOption(
             "task_type",
             ModelOptionType.STR,
-            "The type of task for the embedding. See https://ai.google.dev/gemini-api/docs/embeddings#task-types for supported task types.",  # noqa: E501
+            "The type of task for the embedding. Supported task types: 'semantic_similarity', 'classification', 'clustering', 'retrieval_document', 'retrieval_query', 'question_answering', 'fact_verification', 'code_retrieval_query'",  # noqa: E501
         )
     ]
 
@@ -44,6 +44,14 @@ class GeminiEmbeddingModel(EmbeddingModel):
             return
         for embedding in response.embeddings:
             yield embedding.values if embedding.values else []
+
+    def embed_batch_for_ingest(self, input, batch_size, **kwargs):
+        kwargs["task_type"] = "retrieval_document"
+        return self.embed_batch(input, batch_size, **kwargs)
+
+    def embed_for_search(self, input, **kwargs):
+        kwargs["task_type"] = "retrieval_query"
+        return self.embed(input, **kwargs)
 
 
 @embcli_core.hookimpl

--- a/packages/embcli-gemini/tests/embcli_gemini/test_gemini.py
+++ b/packages/embcli-gemini/tests/embcli_gemini/test_gemini.py
@@ -48,3 +48,25 @@ def test_embed_batch_with_options(gemini_models):
     for emb in embeddings:
         assert isinstance(emb, list)
         assert all(isinstance(x, float) for x in emb)
+
+
+@skip_if_no_api_key
+def test_embed_batch_for_ingest(gemini_models, mocker):
+    for model in gemini_models:
+        input_data = ["hello", "world"]
+        spy = mocker.spy(model, "embed_batch")
+        embeddings = list(model.embed_batch_for_ingest(input_data, None))
+        assert len(embeddings) > 0
+        # Check that the spy was called with the correct model options
+        spy.assert_called_once_with(input_data, None, task_type="retrieval_document")
+
+
+@skip_if_no_api_key
+def test_embed_for_search(gemini_models, mocker):
+    for model in gemini_models:
+        input = "hello world"
+        spy = mocker.spy(model, "embed")
+        embedding = list(model.embed_for_search(input))
+        assert len(embedding) > 0
+        # Check that the spy was called with the correct model options
+        spy.assert_called_once_with(input, task_type="retrieval_query")

--- a/packages/embcli-jina/src/embcli_jina/jina.py
+++ b/packages/embcli-jina/src/embcli_jina/jina.py
@@ -86,6 +86,20 @@ class JinaEmbeddingModel(EmbeddingModel):
                 for embedding in item.get("embeddings", []):
                     yield embedding
 
+    def embed_batch_for_ingest(self, input, batch_size, **kwargs):
+        if self.model_id == "jina-embeddings-v3":
+            kwargs["task"] = "retrieval.passage"
+        elif self.model_id == "jina-colbert-v2":
+            kwargs["input_type"] = "document"
+        return self.embed_batch(input, batch_size, **kwargs)
+
+    def embed_for_search(self, input, **kwargs):
+        if self.model_id == "jina-embeddings-v3":
+            kwargs["task"] = "retrieval.query"
+        elif self.model_id == "jina-colbert-v2":
+            kwargs["input_type"] = "query"
+        return self.embed(input, **kwargs)
+
 
 @embcli_core.hookimpl
 def embedding_model():

--- a/packages/embcli-voyage/src/embcli_voyage/voyage.py
+++ b/packages/embcli-voyage/src/embcli_voyage/voyage.py
@@ -46,6 +46,14 @@ class VoyageEmbeddingModel(EmbeddingModel):
         for embedding in response.embeddings:
             yield embedding  # type: ignore
 
+    def embed_batch_for_ingest(self, input, batch_size, **kwargs):
+        kwargs["input_type"] = "document"
+        return self.embed_batch(input, batch_size, **kwargs)
+
+    def embed_for_search(self, input, **kwargs):
+        kwargs["input_type"] = "query"
+        return self.embed(input, **kwargs)
+
 
 @embcli_core.hookimpl
 def embedding_model():

--- a/packages/embcli-voyage/tests/embcli_voyage/test_voyage.py
+++ b/packages/embcli-voyage/tests/embcli_voyage/test_voyage.py
@@ -48,3 +48,25 @@ def test_embed_batch_with_options(voyage_models):
     assert len(embeddings) == len(input_data)
     for emb in embeddings:
         assert len(emb) == 512
+
+
+@skip_if_no_api_key
+def test_embed_batch_for_ingest(voyage_models, mocker):
+    for model in voyage_models:
+        input_data = ["hello", "world"]
+        spy = mocker.spy(model, "embed_batch")
+        embeddings = list(model.embed_batch_for_ingest(input_data, None))
+        assert len(embeddings) > 0
+        # Check if the spy was called with the correct model options
+        spy.assert_called_once_with(input_data, None, input_type="document")
+
+
+@skip_if_no_api_key
+def test_embed_for_search(voyage_models, mocker):
+    for model in voyage_models:
+        input = "hello world"
+        spy = mocker.spy(model, "embed")
+        embedding = list(model.embed_for_search(input))
+        assert len(embedding) > 0
+        # Check if the spy was called with the correct model options
+        spy.assert_called_once_with(input, input_type="query")


### PR DESCRIPTION
Embedding models often provides options for specific downstream tasks or use cases (for search, for indexing, for clustering, etc.)
To generate optimal embeddings for indexing and searching,
- Add `embed_for_search()` and `embed_batch_for_ingest()` methods to EmbeddingModel 
   - Each subclass of `EmbeddingModel` overrides these methods if needed.
- In `VectorStore.ingest()`, `embed_batch_for_ingest()` is called instead of general `embed_batch()`. Similarly, in `VectorStore.search()`, `embed_for_search()` is called instead of general `embed()`.
