### PR TITLE
Remove python 3.13 support from embcli-voyage package

### DIFF
--- a/.github/workflows/ci-voyage.yml
+++ b/.github/workflows/ci-voyage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/packages/embcli-voyage/pyproject.toml
+++ b/packages/embcli-voyage/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",


### PR DESCRIPTION
The latest version of `voaygeai` library (0.3.2) does not support python 3.13.
https://pypi.org/project/voyageai/0.3.2/