### PR TITLE
Reduce default batch size of CohereEmbeddingModel

### DIFF
--- a/packages/embcli-cohere/src/embcli_cohere/cohere_model.py
+++ b/packages/embcli-cohere/src/embcli_cohere/cohere_model.py
@@ -8,7 +8,7 @@ from embcli_core.models import EmbeddingModel, ModelOption, ModelOptionType
 
 class CohereEmbeddingModel(EmbeddingModel):
     vendor = "cohere"
-    default_batch_size = 100
+    default_batch_size = 50
     model_aliases = [
         ("embed-v4.0", ["embed-v4"]),
         ("embed-english-v3.0", ["embed-en-v3"]),

--- a/packages/embcli-core/src/embcli_core/cli.py
+++ b/packages/embcli-core/src/embcli_core/cli.py
@@ -281,7 +281,7 @@ def ingest_sample(env_file, model_id, vector_store_vendor, persist_path, collect
         return
     # Ingest documents into the vector store
     try:
-        vector_store.ingest(embedding_model, collection, docs, **kwargs)
+        vector_store.ingest(embedding_model, collection, docs, batch_size=embedding_model.default_batch_size, **kwargs)
         click.echo("Documents ingested successfully.")
         click.echo(f"Vector store: {vector_store.vendor} (collection: {collection})")
         if isinstance(vector_store, VectorStoreLocalFS):


### PR DESCRIPTION
Cohere models take a maximum of 96 inputs.