### PR TITLE
Add commands to manipulate collections

### DIFF
--- a/packages/embcli-core/src/embcli_core/cli.py
+++ b/packages/embcli-core/src/embcli_core/cli.py
@@ -349,3 +349,66 @@ def search(env_file, model_id, vector_store_vendor, persist_path, collection, qu
             click.echo(f"Score: {hit.score}, Document ID: {hit.doc.id}, Text: {hit.doc.text}")
     except Exception as e:
         click.echo(f"Error searching documents: {str(e)}", err=True)
+
+
+@cli.command()
+@click.option("--env-file", "-e", default=".env", help="Path to the .env file")
+@click.option(
+    "vector_store_vendor",
+    "--vector-store",
+    default="chroma",
+    help="Vector store to use for storing embeddings",
+    show_default=True,
+)
+@click.option("--persist-path", required=False, help="Path to persist the vector store")
+def collections(env_file, vector_store_vendor, persist_path):
+    """List collections in the vector store."""
+    register_vector_stores(pm())
+    load_env(env_file)
+
+    # Initialize the vector store
+    args = {"persist_path": persist_path} if persist_path else {}
+    vector_store = get_vector_store(vector_store_vendor, args)
+    if not vector_store:
+        click.echo(f"Error: Unknown vector store '{vector_store_vendor}'.", err=True)
+        return
+
+    # List collections in the vector store
+    try:
+        collections = vector_store.list_collections()
+        click.echo("Collections:")
+        for collection in collections:
+            click.echo(f"- {collection}")
+    except Exception as e:
+        click.echo(f"Error listing collections: {str(e)}", err=True)
+
+
+@cli.command()
+@click.option("--env-file", "-e", default=".env", help="Path to the .env file")
+@click.option(
+    "vector_store_vendor",
+    "--vector-store",
+    default="chroma",
+    help="Vector store to use for storing embeddings",
+    show_default=True,
+)
+@click.option("--persist-path", required=False, help="Path to persist the vector store")
+@click.option("--collection", "-c", required=True, help="Collection name to delete")
+def delete_collection(env_file, vector_store_vendor, persist_path, collection):
+    """Delete a collection from the vector store."""
+    register_vector_stores(pm())
+    load_env(env_file)
+
+    # Initialize the vector store
+    args = {"persist_path": persist_path} if persist_path else {}
+    vector_store = get_vector_store(vector_store_vendor, args)
+    if not vector_store:
+        click.echo(f"Error: Unknown vector store '{vector_store_vendor}'.", err=True)
+        return
+
+    # Delete the collection from the vector store
+    try:
+        vector_store.delete_collection(collection)
+        click.echo(f"Collection '{collection}' deleted successfully.")
+    except Exception as e:
+        click.echo(f"Error deleting collection: {str(e)}", err=True)

--- a/packages/embcli-core/src/embcli_core/vector_store/chroma.py
+++ b/packages/embcli-core/src/embcli_core/vector_store/chroma.py
@@ -39,6 +39,15 @@ class ChromaVectorStore(VectorStoreLocalFS):
             hits.append(HitDocument(score=score, doc=doc))
         return hits
 
+    def list_collections(self) -> list[str]:
+        """List all collections."""
+        collections = self.client.list_collections()
+        return [collection.name for collection in collections]
+
+    def delete_collection(self, collection: str):
+        """Delete a collection."""
+        self.client.delete_collection(name=collection)
+
 
 @hookimpl
 def vector_store() -> tuple[type[ChromaVectorStore], Callable[[dict], ChromaVectorStore]]:

--- a/packages/embcli-core/src/embcli_core/vector_stores.py
+++ b/packages/embcli-core/src/embcli_core/vector_stores.py
@@ -50,6 +50,16 @@ class VectorStore(ABC):
         """Search for the top K documents."""
         pass
 
+    @abstractmethod
+    def list_collections(self) -> list[str]:
+        """List all collections."""
+        pass
+
+    @abstractmethod
+    def delete_collection(self, collection: str):
+        """Delete a collection."""
+        pass
+
 
 class VectorStoreLocalFS(VectorStore):
     """Local file system vector store."""

--- a/packages/embcli-core/tests/embcli_core/mock_vector_store.py
+++ b/packages/embcli-core/tests/embcli_core/mock_vector_store.py
@@ -27,6 +27,15 @@ class MockVectorStore(VectorStoreLocalFS):
         hits = [HitDocument(score=random.uniform(0, 1), doc=doc) for doc in docs]
         return hits
 
+    def list_collections(self) -> list[str]:
+        """List all collections."""
+        return list(self.cache.keys())
+
+    def delete_collection(self, collection: str):
+        """Delete a collection."""
+        if collection in self.cache:
+            del self.cache[collection]
+
 
 @embcli_core.hookimpl
 def vector_store() -> tuple[type[MockVectorStore], Callable[[dict], VectorStore]]:

--- a/packages/embcli-core/tests/embcli_core/test_cli_collections.py
+++ b/packages/embcli-core/tests/embcli_core/test_cli_collections.py
@@ -1,0 +1,91 @@
+from click.testing import CliRunner
+from embcli_core.cli import collections, delete_collection, ingest_sample
+from embcli_core.vector_store import chroma
+
+
+def test_list_delete_collection_command(plugin_manager, mocker, tmp_path):
+    plugin_manager.register(chroma)
+    mocker.patch("embcli_core.cli._pm", plugin_manager)
+
+    test_persist_path = tmp_path / "test_db"
+    test_persist_path.mkdir(parents=True, exist_ok=True)
+
+    runner = CliRunner()
+    # Create collections with different corpus
+    for corpus in ["cat-names-en", "dishes-en", "movies-en"]:
+        result = runner.invoke(
+            ingest_sample,
+            [
+                "--model",
+                "embedding-mock-1",
+                "--vector-store",
+                "chroma",
+                "--persist-path",
+                str(test_persist_path),
+                "--collection",
+                f"test_collection_{corpus}",
+                "--corpus",
+                corpus,
+            ],
+        )
+        assert result.exit_code == 0
+        assert "chroma" in result.output
+
+    # Check if created collections are correctly listed
+    result = runner.invoke(
+        collections,
+        [
+            "--vector-store",
+            "chroma",
+            "--persist-path",
+            str(test_persist_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "test_collection_cat-names-en" in result.output
+    assert "test_collection_dishes-en" in result.output
+    assert "test_collection_movies-en" in result.output
+
+    # Delete a collection
+    result = runner.invoke(
+        delete_collection,
+        [
+            "--vector-store",
+            "chroma",
+            "--persist-path",
+            str(test_persist_path),
+            "--collection",
+            "test_collection_cat-names-en",
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Check if the collection was deleted
+    result = runner.invoke(
+        collections,
+        [
+            "--vector-store",
+            "chroma",
+            "--persist-path",
+            str(test_persist_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "test_collection_cat-names-en" not in result.output
+    assert "test_collection_dishes-en" in result.output
+    assert "test_collection_movies-en" in result.output
+
+    # Attempt to delete a non-existing collection
+    result = runner.invoke(
+        delete_collection,
+        [
+            "--vector-store",
+            "chroma",
+            "--persist-path",
+            str(test_persist_path),
+            "--collection",
+            "test_collection_cat-names-en",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Collection [test_collection_cat-names-en] does not exists" in result.output

--- a/packages/embcli-core/tests/embcli_core/vector_store/test_chroma.py
+++ b/packages/embcli-core/tests/embcli_core/vector_store/test_chroma.py
@@ -60,3 +60,25 @@ def test_search_success():
 
         assert len(results) == top_k
         assert all(isinstance(hit.score, float) for hit in results)
+
+
+def test_list_delete_collections(mock_model):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = ChromaVectorStore(persist_path=tmpdir)
+        collection1 = "collection1"
+        collection2 = "collection2"
+        docs = [Document(id=f"id{i}", text=f"text{i}") for i in range(10)]
+
+        store.ingest(model=mock_model, collection=collection1, docs=docs)
+        store.ingest(model=mock_model, collection=collection2, docs=docs)
+
+        collections = store.list_collections()
+        assert len(collections) == 2
+        assert collection1 in collections
+        assert collection2 in collections
+
+        # Delete one collection
+        store.delete_collection(collection1)
+        collections = store.list_collections()
+        assert len(collections) == 1
+        assert collection2 in collections


### PR DESCRIPTION
1. Add `collections` command to list all collections in a vector store.
```
$ emb collections
Collections:
- catcafe
- menu-ja
- menu
```

2. Add `delete-collectoin` command to delete a specific collection from a vector store.
```
$ emb delete-collection -c menu
Collection 'menu' deleted successfully.
```