### PR TITLE
Remove deprecated license classifiers

### DIFF
--- a/packages/embcli-cohere/pyproject.toml
+++ b/packages/embcli-cohere/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "cohere plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = { file = "LICENSE.txt" }
+license = { text = "Apache-2.0" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/packages/embcli-cohere/pyproject.toml
+++ b/packages/embcli-cohere/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "cohere plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = "Apache-2.0"
+license = { file = "LICENSE.txt" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Utilities",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = ["embcli-core>=0.0.5", "cohere>=5.15.0"]

--- a/packages/embcli-core/pyproject.toml
+++ b/packages/embcli-core/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.9-dev"
 description = "embcli - CLI for Embeddings"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = { file = "LICENSE.txt" }
+license = { text = "Apache-2.0" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/packages/embcli-core/pyproject.toml
+++ b/packages/embcli-core/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.9-dev"
 description = "embcli - CLI for Embeddings"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = "Apache-2.0"
+license = { file = "LICENSE.txt" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Utilities",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/embcli-gemini/pyproject.toml
+++ b/packages/embcli-gemini/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "gemini plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = "Apache-2.0"
+license = { file = "LICENSE.txt" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Utilities",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = ["embcli-core>=0.0.5", "google-genai>=1.14.0"]

--- a/packages/embcli-gemini/pyproject.toml
+++ b/packages/embcli-gemini/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "gemini plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = { file = "LICENSE.txt" }
+license = { text = "Apache-2.0" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/packages/embcli-jina/pyproject.toml
+++ b/packages/embcli-jina/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "jina plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = { file = "LICENSE.txt" }
+license = { text = "Apache-2.0" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/packages/embcli-jina/pyproject.toml
+++ b/packages/embcli-jina/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "jina plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = "Apache-2.0"
+license = { file = "LICENSE.txt" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Utilities",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = ["embcli-core>=0.0.5", "httpx>=0.28.1"]

--- a/packages/embcli-llamacpp/pyproject.toml
+++ b/packages/embcli-llamacpp/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.3-dev"
 description = "llama-cpp-python plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = { file = "LICENSE.txt" }
+license = { text = "Apache-2.0" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/packages/embcli-llamacpp/pyproject.toml
+++ b/packages/embcli-llamacpp/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.3-dev"
 description = "llama-cpp-python plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = "Apache-2.0"
+license = { file = "LICENSE.txt" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Utilities",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = ["embcli-core>=0.0.8", "llama-cpp-python>=0.3.9"]

--- a/packages/embcli-mistral/pyproject.toml
+++ b/packages/embcli-mistral/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "mistral plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = "Apache-2.0"
+license = { file = "LICENSE.txt" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Utilities",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = ["embcli-core>=0.0.5", "mistralai>=1.7.0"]

--- a/packages/embcli-mistral/pyproject.toml
+++ b/packages/embcli-mistral/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "mistral plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = { file = "LICENSE.txt" }
+license = { text = "Apache-2.0" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/packages/embcli-openai/pyproject.toml
+++ b/packages/embcli-openai/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "openai plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = "Apache-2.0"
+license = { file = "LICENSE.txt" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Utilities",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = ["embcli-core>=0.0.5", "openai>=1.77.0"]

--- a/packages/embcli-openai/pyproject.toml
+++ b/packages/embcli-openai/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "openai plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = { file = "LICENSE.txt" }
+license = { text = "Apache-2.0" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/packages/embcli-sbert/pyproject.toml
+++ b/packages/embcli-sbert/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.2-dev"
 description = "sentence-transformers plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = { file = "LICENSE.txt" }
+license = { text = "Apache-2.0" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/packages/embcli-sbert/pyproject.toml
+++ b/packages/embcli-sbert/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.2-dev"
 description = "sentence-transformers plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = "Apache-2.0"
+license = { file = "LICENSE.txt" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Utilities",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = ["embcli-core>=0.0.7", "sentence-transformers>=4.1.0"]

--- a/packages/embcli-voyage/pyproject.toml
+++ b/packages/embcli-voyage/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "voyage plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = "Apache-2.0"
+license = { file = "LICENSE.txt" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -16,7 +16,6 @@ classifiers = [
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Utilities",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = ["embcli-core>=0.0.5", "voyageai>=0.3.2"]

--- a/packages/embcli-voyage/pyproject.toml
+++ b/packages/embcli-voyage/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.6-dev"
 description = "voyage plugin for embcli"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = { file = "LICENSE.txt" }
+license = { text = "Apache-2.0" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.9-dev"
 description = "embcli - CLI for Embeddings"
 readme = "README.md"
 authors = [{ name = "Tomoko Uchida", email = "tomoko.uchida.1111@gmail.com" }]
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 keywords = ["cli", "llm", "nlp", "embeddings"]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Terminals",
     "Topic :: Text Processing :: Linguistic",
     "Topic :: Utilities",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = []


### PR DESCRIPTION
As of setuptools v77.0.0, `License ::` classifiers have been deprecated, and this blocks Cloudflare Pages build.
https://setuptools.pypa.io/en/stable/history.html#v77-0-0
