### PR TITLE
Add codestral-embed support to emcli-mistral

### DIFF
--- a/packages/embcli-mistral/pyproject.toml
+++ b/packages/embcli-mistral/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Utilities",
 ]
 requires-python = ">=3.10"
-dependencies = ["embcli-core>=0.0.5", "mistralai>=1.7.0"]
+dependencies = ["embcli-core>=0.0.5", "mistralai>=1.8.1"]
 
 [project.urls]
 "Repository" = "https://github.com/mocobeta/embcli"

--- a/packages/embcli-mistral/src/embcli_mistral/mistral.py
+++ b/packages/embcli-mistral/src/embcli_mistral/mistral.py
@@ -2,15 +2,21 @@ import os
 from typing import Iterator
 
 import embcli_core
-from embcli_core.models import EmbeddingModel
+from embcli_core.models import EmbeddingModel, ModelOption, ModelOptionType
 from mistralai import Mistral
 
 
 class MistralEmbeddingModel(EmbeddingModel):
     vendor = "mistral"
     default_batch_size = 100
-    model_aliases = [("mistral-embed", [])]
-    valid_options = []
+    model_aliases = [("mistral-embed", []), ("codestral-embed", [])]
+    valid_options = [
+        ModelOption(
+            name="output_dimension",
+            type=ModelOptionType.INT,
+            description="The dimesions of the output embedding, defaults to 1536 and has a maximum value of 3072. Only supprted in codestral-embed model.",  # noqa: E501
+        )
+    ]
 
     def __init__(self, model_id: str):
         super().__init__(model_id)

--- a/packages/embcli-mistral/tests/embcli_mistral/test_mistral.py
+++ b/packages/embcli-mistral/tests/embcli_mistral/test_mistral.py
@@ -35,3 +35,18 @@ def test_embed_one_batch_yields_embeddings(mistral_models):
         for emb in embeddings:
             assert isinstance(emb, list)
             assert all(isinstance(x, float) for x in emb)
+
+
+@skip_if_no_api_key
+def test_embed_batch_with_options(mistral_models):
+    for model in mistral_models:
+        if model.model_id != "codestral-embed":
+            continue
+        input_data = ["hello", "world"]
+        options = {"output_dimension": "512"}
+
+        embeddings = list(model.embed_batch(input_data, None, **options))
+        assert len(embeddings) == len(input_data)
+        for emb in embeddings:
+            assert len(emb) == 512
+            assert all(isinstance(x, float) for x in emb)

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "embcli-core", editable = "packages/embcli-core" },
-    { name = "mistralai", specifier = ">=1.7.0" },
+    { name = "mistralai", specifier = ">=1.8.1" },
 ]
 
 [[package]]
@@ -1380,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "1.7.0"
+version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eval-type-backport" },
@@ -1389,9 +1389,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/d0/11e0116a02aa88701422ccc048185ed8834754f3b94140bfad09620c9d11/mistralai-1.7.0.tar.gz", hash = "sha256:94e3eb23c1d3ed398a95352062fd8c92993cc3754ed18e9a35b60aa3db0bd103", size = 141981, upload-time = "2025-04-16T19:42:56.703Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/c1/b3cecb41695fd6cb5483fbb8ecaceb5586346c3ed53a78808d10c1b537c4/mistralai-1.8.1.tar.gz", hash = "sha256:b967ca443726b71ec45632cb33825ee2e55239a652e73c2bda11f7cc683bf6e5", size = 175819, upload-time = "2025-05-28T19:13:42.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/77/eb7519ddfccb6428ac430129e7b42cc662e710cb719f82c0ffe79ab50859/mistralai-1.7.0-py3-none-any.whl", hash = "sha256:e0e75ab8508598d69ae19b14d9d7e905db6259a2de3cf9204946a27e9bf81c5d", size = 301483, upload-time = "2025-04-16T19:42:55.434Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/14/e9ef675928768f508dfcedbb0e0ed601784a6911620a2bc25c9065921420/mistralai-1.8.1-py3-none-any.whl", hash = "sha256:badfc7e6832d894b3e9071d92ad621212b7cccd7df622c6cacdb525162ae338f", size = 373197, upload-time = "2025-05-28T19:13:41.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Upgrade mistralai to 1.8.1
- Add [codestral-embed](https://docs.mistral.ai/capabilities/embeddings/code_embeddings/) model to embcli-mistral plugin
